### PR TITLE
Remove CODECOV_TOKEN from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,6 @@ jobs:
         if: ${{ matrix.run-coverage && github.repository == 'Ajimaru/ajitroids' }}
         uses: codecov/codecov-action@v5.5.2
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
           flags: unittests
           fail_ci_if_error: false


### PR DESCRIPTION
This pull request makes a small update to the CI workflow by removing the use of the `CODECOV_TOKEN` secret from the Codecov upload step. This simplifies the configuration and may be possible because public repositories do not require a token for Codecov uploads.

* Removed the `token` parameter (and use of `CODECOV_TOKEN` secret) from the Codecov upload step in `.github/workflows/ci.yml`Remove CODECOV_TOKEN from workflow for security.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove CODECOV_TOKEN from the CI Codecov step to use tokenless uploads for this public repo. This reduces secret exposure and simplifies the workflow without changing coverage upload behavior (still uploads coverage.xml with flags and does not fail CI on upload errors).

<sup>Written for commit 9316d252eb24fb07ccd53ffe028d3b8567da979d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow configuration for Codecov integration to use default token handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->