### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,12 +8,14 @@ updates:
     # Workflow files stored in the default location of `.github/workflows`
     # You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.
     directory: "/"
+    target-branch: dev
     schedule:
       interval: "weekly"
 
   # Keep Python dependencies up to date
   - package-ecosystem: "pip"
     directory: "/"
+    target-branch: dev
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5


### PR DESCRIPTION
This pull request updates the Dependabot configuration to ensure that automated dependency update pull requests are targeted at the `dev` branch instead of the default branch. This helps keep dependencies up to date in the development workflow before changes are merged into the main branch.

Configuration updates:

* Updated the `target-branch` for both GitHub Actions and Python (`pip`) dependencies to `dev` in `.github/dependabot.yml`, so Dependabot PRs will be opened against the development branch instead of the default branch.